### PR TITLE
fix: server_start.sh 수정

### DIFF
--- a/server/scripts/server_start.sh
+++ b/server/scripts/server_start.sh
@@ -4,5 +4,5 @@
 # 2 : nohup - 해당 명령어를 입력하는 터미널의 연결이 끊켜도 프로세스를 실행시킴.
 # 2 : > /dev/null 2> - 해당 명령어로 인해 발생되는 출력내용(에러 포함)을 버림
 cd /home/ubuntu/build
-sudo nohup java -jar server-0.0.1-SNAPSHOT.jar > /dev/null 2> /dev/null < /dev/null &
+nohup java -jar server-0.0.1-SNAPSHOT.jar > /dev/null 2> /dev/null < /dev/null &
 #sudo nohup java -jar server-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev > /dev/null 2> /dev/null < /dev/null &


### PR DESCRIPTION
- terminal로 접속하여 root 계정에서 sudo 명령어로 빌드를 실행시키면 에러가 발생되는 현상 발견.. 하지만, root 계정에서 sudo 없이 하면 정상작동함